### PR TITLE
Space out "Use Guide" instructions for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ Tags are currently unsupported.
 
 ![ct1](https://github.com/ekona03/MC-Formatter/assets/76677529/3f714b4e-96f4-47bb-b2b7-8127c37c0c02)
 
+##
+
 ### Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
 
 ![c2 5](https://github.com/ekona03/MC-Formatter/assets/76677529/b3754e52-39e0-4429-ad22-cde9de713e66)
 ![ct2](https://github.com/ekona03/MC-Formatter/assets/76677529/c9ead4bd-6965-405b-8054-5971bd934c5d)
 
+
+##
 
 ### Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Tags are currently unsupported.
 
 # Use Guide
 
-Upon running the exe, you should see this text appear in your command terminal.
+* Upon running the exe, you should see this text appear in your command terminal.
 
 ![ct1](https://github.com/ekona03/MC-Formatter/assets/76677529/3f714b4e-96f4-47bb-b2b7-8127c37c0c02)
 
-Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
+* Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
 
 ![c2 5](https://github.com/ekona03/MC-Formatter/assets/76677529/b3754e52-39e0-4429-ad22-cde9de713e66)
 ![ct2](https://github.com/ekona03/MC-Formatter/assets/76677529/c9ead4bd-6965-405b-8054-5971bd934c5d)
 
 
-Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
+* Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
 
 ![ct3](https://github.com/ekona03/MC-Formatter/assets/76677529/d241a380-d292-49bc-a6c1-254f45befcd6)
 
-To copy the formatted recipe out, highlight it, and RIGHT CLICK to copy from the terminal.
+* To copy the formatted recipe out, highlight it, and RIGHT CLICK to copy from the terminal.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tags are currently unsupported.
 
 ##
 
-### Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
+### Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by **RIGHT CLICKING** it in, **not** CTRL V.
 
 ![c2 5](https://github.com/ekona03/MC-Formatter/assets/76677529/b3754e52-39e0-4429-ad22-cde9de713e66)
 ![ct2](https://github.com/ekona03/MC-Formatter/assets/76677529/c9ead4bd-6965-405b-8054-5971bd934c5d)
@@ -33,4 +33,4 @@ Tags are currently unsupported.
 
 ![ct3](https://github.com/ekona03/MC-Formatter/assets/76677529/d241a380-d292-49bc-a6c1-254f45befcd6)
 
-### To copy the formatted recipe out, highlight it, and RIGHT CLICK to copy from the terminal.
+### To copy the formatted recipe out, highlight it, and **RIGHT CLICK** to copy from the terminal.

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Tags are currently unsupported.
 
 # Use Guide
 
-* Upon running the exe, you should see this text appear in your command terminal.
+### Upon running the exe, you should see this text appear in your command terminal.
 
 ![ct1](https://github.com/ekona03/MC-Formatter/assets/76677529/3f714b4e-96f4-47bb-b2b7-8127c37c0c02)
 
-* Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
+### Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by RIGHT CLICKING it in, not CTRL V.
 
 ![c2 5](https://github.com/ekona03/MC-Formatter/assets/76677529/b3754e52-39e0-4429-ad22-cde9de713e66)
 ![ct2](https://github.com/ekona03/MC-Formatter/assets/76677529/c9ead4bd-6965-405b-8054-5971bd934c5d)
 
 
-* Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
+### Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
 
 ![ct3](https://github.com/ekona03/MC-Formatter/assets/76677529/d241a380-d292-49bc-a6c1-254f45befcd6)
 
-* To copy the formatted recipe out, highlight it, and RIGHT CLICK to copy from the terminal.
+### To copy the formatted recipe out, highlight it, and RIGHT CLICK to copy from the terminal.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Tags are currently unsupported.
 
 # Use Guide
 
-### Upon running the exe, you should see this text appear in your command terminal.
+* Upon running the exe, you should see this text appear in your command terminal.
 
 ![ct1](https://github.com/ekona03/MC-Formatter/assets/76677529/3f714b4e-96f4-47bb-b2b7-8127c37c0c02)
 
 ##
 
-### Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by **RIGHT CLICKING** it in, **not** CTRL V.
+* Next, copy the recipe you made with CraftTweaker, and paste it into the command terminal by **RIGHT CLICKING** it in, **not** CTRL V.
 
 ![c2 5](https://github.com/ekona03/MC-Formatter/assets/76677529/b3754e52-39e0-4429-ad22-cde9de713e66)
 ![ct2](https://github.com/ekona03/MC-Formatter/assets/76677529/c9ead4bd-6965-405b-8054-5971bd934c5d)
@@ -29,8 +29,8 @@ Tags are currently unsupported.
 
 ##
 
-### Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
+* Finally, press "ENTER" and the recipe will be formatted, along with the program prompting you to paste in another recipe, until you type "exit".
 
 ![ct3](https://github.com/ekona03/MC-Formatter/assets/76677529/d241a380-d292-49bc-a6c1-254f45befcd6)
 
-### To copy the formatted recipe out, highlight it, and **RIGHT CLICK** to copy from the terminal.
+* To copy the formatted recipe out, highlight it, and **RIGHT CLICK** to copy from the terminal.


### PR DESCRIPTION
I tried to space out the instructions for readability by adding lines to separate each step and adding bullet points to each step.